### PR TITLE
Add simple Dockerfile

### DIFF
--- a/diy_asylum_frontend/.dockerignore
+++ b/diy_asylum_frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/diy_asylum_frontend/Dockerfile
+++ b/diy_asylum_frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8
+
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --only=production
+
+COPY . .
+EXPOSE 3000
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Adds a simple Dockerfile. I'm using this to work out a deployment setup. Once we add node we'll have to update the file to run the node command rather than `npm start`. 