### PR TITLE
Encryption/decryption endpoints

### DIFF
--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -8,7 +8,10 @@ dependencies {
     implementation 'com.muquit.libsodiumjna:libsodium-jna:1.0.4'
     implementation 'org.apache.commons:commons-text:1.6'
     implementation 'org.apache.syncope.common:syncope-common-lib:2.0.11'
-
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation 'org.springframework.boot:spring-boot-starter-json:2.1.2.RELEASE'
+    implementation 'commons-codec:commons-codec:1.11'
+    
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testImplementation 'org.junit-pioneer:junit-pioneer:0.3.0'
     testImplementation 'commons-codec:commons-codec:1.11'

--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
     implementation 'org.springframework.boot:spring-boot-starter-json:2.1.2.RELEASE'
     implementation 'commons-codec:commons-codec:1.11'
-    
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testImplementation 'org.junit-pioneer:junit-pioneer:0.3.0'
     testImplementation 'commons-codec:commons-codec:1.11'

--- a/encryption/src/main/java/com/diyasylum/encryption/EncryptionHandler.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/EncryptionHandler.java
@@ -1,0 +1,22 @@
+package com.diyasylum.encryption;
+
+import com.diyasylum.encryption.models.EncryptedMessage;
+import com.diyasylum.encryption.models.EncryptionPackage;
+import com.diyasylum.encryption.models.UnencryptedMessage;
+
+public class EncryptionHandler {
+
+  public static EncryptionPackage handleEncryption(UnencryptedMessage message) {
+    String password = PasswordGenerator.getPassword();
+    SecretBox box = new SecretBox(password);
+    EncryptedMessage encryptedMessage = box.encrypt(message.getMessage()).get();
+    return new EncryptionPackage(encryptedMessage, password);
+  }
+
+  public static UnencryptedMessage handleDecryption(EncryptionPackage encryptionPackage) {
+    String password = encryptionPackage.getPassword();
+    EncryptedMessage encryptedMessage = encryptionPackage.getMessage();
+    SecretBox box = new SecretBox(password);
+    return new UnencryptedMessage(box.decrypt(encryptedMessage).get());
+  }
+}

--- a/encryption/src/main/java/com/diyasylum/encryption/EncryptionHandler.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/EncryptionHandler.java
@@ -5,7 +5,7 @@ import com.diyasylum.encryption.models.EncryptionPackage;
 import com.diyasylum.encryption.models.UnencryptedMessage;
 
 public class EncryptionHandler {
-
+  // Is there a better way to handle missing values here / propagate errors?
   public static EncryptionPackage handleEncryption(UnencryptedMessage message) {
     String password = PasswordGenerator.getPassword();
     SecretBox box = new SecretBox(password);

--- a/encryption/src/main/java/com/diyasylum/encryption/PasswordGenerator.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/PasswordGenerator.java
@@ -3,7 +3,7 @@ package com.diyasylum.encryption;
 import org.apache.commons.text.RandomStringGenerator;
 import org.apache.syncope.common.lib.SecureTextRandomProvider;
 
-class PasswordGenerator {
+public class PasswordGenerator {
 
   private static char[][] range = {{'a', 'z'}, {'0', '9'}, {'A', 'Z'}};
   private static RandomStringGenerator generator =

--- a/encryption/src/main/java/com/diyasylum/encryption/models/EncryptedMessage.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/models/EncryptedMessage.java
@@ -1,11 +1,19 @@
 package com.diyasylum.encryption.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
+
 public class EncryptedMessage {
   private byte[] encryptedMessage;
   private byte[] salt;
   private byte[] nonce;
 
-  public EncryptedMessage(byte[] encryptedMessage, byte[] salt, byte[] nonce) {
+  @JsonCreator
+  public EncryptedMessage(
+      @JsonProperty("encryptedMessage") byte[] encryptedMessage,
+      @JsonProperty("salt") byte[] salt,
+      @JsonProperty("nonce") byte[] nonce) {
     this.encryptedMessage = encryptedMessage;
     this.salt = salt;
     this.nonce = nonce;
@@ -21,5 +29,15 @@ public class EncryptedMessage {
 
   public byte[] getNonce() {
     return nonce;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EncryptedMessage message = (EncryptedMessage) o;
+    return Arrays.equals(encryptedMessage, message.encryptedMessage)
+        && Arrays.equals(salt, message.salt)
+        && Arrays.equals(nonce, message.nonce);
   }
 }

--- a/encryption/src/main/java/com/diyasylum/encryption/models/EncryptionPackage.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/models/EncryptionPackage.java
@@ -1,0 +1,25 @@
+package com.diyasylum.encryption.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EncryptionPackage {
+  private EncryptedMessage message;
+  private String password;
+
+  @JsonCreator
+  public EncryptionPackage(
+      @JsonProperty("message") EncryptedMessage message,
+      @JsonProperty("password") String password) {
+    this.message = message;
+    this.password = password;
+  }
+
+  public EncryptedMessage getMessage() {
+    return message;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+}

--- a/encryption/src/main/java/com/diyasylum/encryption/models/UnencryptedMessage.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/models/UnencryptedMessage.java
@@ -1,9 +1,13 @@
 package com.diyasylum.encryption.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class UnencryptedMessage {
   private String message;
 
-  public UnencryptedMessage(String message) {
+  @JsonCreator
+  public UnencryptedMessage(@JsonProperty("message") String message) {
     this.message = message;
   }
 

--- a/encryption/src/main/java/com/diyasylum/encryption/models/UnencryptedMessage.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/models/UnencryptedMessage.java
@@ -1,0 +1,13 @@
+package com.diyasylum.encryption.models;
+
+public class UnencryptedMessage {
+  private String message;
+
+  public UnencryptedMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/encryption/src/main/java/com/diyasylum/encryption/serializers/EncryptedMessageSerializer.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/serializers/EncryptedMessageSerializer.java
@@ -1,7 +1,6 @@
 package com.diyasylum.encryption.serializers;
 
 import com.diyasylum.encryption.models.EncryptedMessage;
-import org.springframework.boot.jackson.JsonComponent;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,45 +10,45 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.node.TextNode;
-import org.apache.commons.codec.binary.Base64;
 import java.io.IOException;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.boot.jackson.JsonComponent;
 
 @JsonComponent
 public class EncryptedMessageSerializer {
 
-    private static Base64 base64 = new Base64();
-  
-    public static class EncryptedMessageJsonSerializer 
-      extends JsonSerializer<EncryptedMessage> {
- 
-        @Override
-        public void serialize(EncryptedMessage message, JsonGenerator jsonGenerator, 
-          SerializerProvider serializerProvider) throws IOException, 
-          JsonProcessingException {
-  
-            jsonGenerator.writeStartObject();
-            jsonGenerator.writeStringField(
-              "encryptedMessage", base64.encodeBase64String(message.getEncryptedMessage()));
-            jsonGenerator.writeStringField(
-              "salt", base64.encodeBase64String(message.getSalt()));
-            jsonGenerator.writeStringField(
-              "nonce", base64.encodeBase64String(message.getNonce()));
-            jsonGenerator.writeEndObject();
-        }
+  private static Base64 base64 = new Base64();
+
+  public static class EncryptedMessageJsonSerializer extends JsonSerializer<EncryptedMessage> {
+
+    @Override
+    public void serialize(
+        EncryptedMessage message,
+        JsonGenerator jsonGenerator,
+        SerializerProvider serializerProvider)
+        throws IOException, JsonProcessingException {
+
+      jsonGenerator.writeStartObject();
+      jsonGenerator.writeStringField(
+          "encryptedMessage", base64.encodeBase64String(message.getEncryptedMessage()));
+      jsonGenerator.writeStringField("salt", base64.encodeBase64String(message.getSalt()));
+      jsonGenerator.writeStringField("nonce", base64.encodeBase64String(message.getNonce()));
+      jsonGenerator.writeEndObject();
     }
- 
-    public static class EncryptedMessageJsonDeserializer 
-      extends JsonDeserializer<EncryptedMessage> {
-  
-        @Override
-        public EncryptedMessage deserialize(JsonParser jsonParser, 
-          DeserializationContext deserializationContext)
-          throws IOException, JsonProcessingException {
-            TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
-            byte[] encryptedMessage = base64.decodeBase64(((TextNode) treeNode.get("encryptedMessage")).asText());
-            byte[] salt = base64.decodeBase64(((TextNode) treeNode.get("salt")).asText());
-            byte[] nonce = base64.decodeBase64(((TextNode) treeNode.get("nonce")).asText());
-            return new EncryptedMessage(encryptedMessage, salt, nonce);
-        }
+  }
+
+  public static class EncryptedMessageJsonDeserializer extends JsonDeserializer<EncryptedMessage> {
+
+    @Override
+    public EncryptedMessage deserialize(
+        JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException, JsonProcessingException {
+      TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+      byte[] encryptedMessage =
+          base64.decodeBase64(((TextNode) treeNode.get("encryptedMessage")).asText());
+      byte[] salt = base64.decodeBase64(((TextNode) treeNode.get("salt")).asText());
+      byte[] nonce = base64.decodeBase64(((TextNode) treeNode.get("nonce")).asText());
+      return new EncryptedMessage(encryptedMessage, salt, nonce);
     }
+  }
 }

--- a/encryption/src/main/java/com/diyasylum/encryption/serializers/EncryptedMessageSerializer.java
+++ b/encryption/src/main/java/com/diyasylum/encryption/serializers/EncryptedMessageSerializer.java
@@ -1,0 +1,55 @@
+package com.diyasylum.encryption.serializers;
+
+import com.diyasylum.encryption.models.EncryptedMessage;
+import org.springframework.boot.jackson.JsonComponent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.commons.codec.binary.Base64;
+import java.io.IOException;
+
+@JsonComponent
+public class EncryptedMessageSerializer {
+
+    private static Base64 base64 = new Base64();
+  
+    public static class EncryptedMessageJsonSerializer 
+      extends JsonSerializer<EncryptedMessage> {
+ 
+        @Override
+        public void serialize(EncryptedMessage message, JsonGenerator jsonGenerator, 
+          SerializerProvider serializerProvider) throws IOException, 
+          JsonProcessingException {
+  
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(
+              "encryptedMessage", base64.encodeBase64String(message.getEncryptedMessage()));
+            jsonGenerator.writeStringField(
+              "salt", base64.encodeBase64String(message.getSalt()));
+            jsonGenerator.writeStringField(
+              "nonce", base64.encodeBase64String(message.getNonce()));
+            jsonGenerator.writeEndObject();
+        }
+    }
+ 
+    public static class EncryptedMessageJsonDeserializer 
+      extends JsonDeserializer<EncryptedMessage> {
+  
+        @Override
+        public EncryptedMessage deserialize(JsonParser jsonParser, 
+          DeserializationContext deserializationContext)
+          throws IOException, JsonProcessingException {
+            TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+            byte[] encryptedMessage = base64.decodeBase64(((TextNode) treeNode.get("encryptedMessage")).asText());
+            byte[] salt = base64.decodeBase64(((TextNode) treeNode.get("salt")).asText());
+            byte[] nonce = base64.decodeBase64(((TextNode) treeNode.get("nonce")).asText());
+            return new EncryptedMessage(encryptedMessage, salt, nonce);
+        }
+    }
+}

--- a/encryption/src/test/java/com/diyasylum/encryption/models/EncryptedMessageTest.java
+++ b/encryption/src/test/java/com/diyasylum/encryption/models/EncryptedMessageTest.java
@@ -1,0 +1,28 @@
+package com.diyasylum.encryption.models;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.Test;
+
+class EncryptedMessageTest {
+  private static Base64 base64 = new Base64();
+
+  @Test
+  void testSerializationAndDeserialization() throws IOException {
+    EncryptedMessage encryptedMessage =
+        new EncryptedMessage(
+            base64.decodeBase64("itkNJqRclSElL/iaUugskBZCaCmXCf67coYuw3T5"),
+            base64.decodeBase64("C1wxtjxCPusWK1naAnnVyQ=="),
+            base64.decodeBase64("7yKw+IMNRouQFrIv5P/sY+Ag3D4XVwbq"));
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String serializedJson = objectMapper.writeValueAsString(encryptedMessage);
+
+    EncryptedMessage deserializedMessage =
+        objectMapper.readValue(serializedJson, EncryptedMessage.class);
+    assertEquals(encryptedMessage, deserializedMessage);
+  }
+}

--- a/formserver/README.md
+++ b/formserver/README.md
@@ -41,3 +41,39 @@ docker run -p 8080:8080 -t diyasylum/formserver
 ```
 
 You can test it by running the curl command from above
+
+## Encryption endpoints
+
+This module also contains endpoints for encryption and decryption of user state, so that they can safely save and resume their progress. The user state is sent as a string to the encryption endpoint, which generates a password for the user and encrypts their state using the password. A sample encryption request looks like:
+
+```bash
+curl -X POST localhost:8080/encryption/v1 -H "Content-Type: application/json" --data '{
+        "message": "user state"
+    }'
+```
+
+The user receives a payload which looks like:
+
+```bash
+{
+   "message":{
+      "encryptedMessage":"A4SqpsrYEf2a3XWdYQ5h3SukMZEQZWbd1VU=",
+      "salt":"63zV+FGiXDCewU4BqSQgkg==",
+      "nonce":"7KxHxQSmDlHdI2+tsZp5BpaZswKPayYx"
+   },
+   "password":"YdkNfIEro2aokq5l"
+}
+```
+
+When the user wants to resume their progress, they can send this payload back to the decryption endpoint to recover their state:
+
+```bash
+curl -X POST localhost:8080/decryption/v1 -H "Content-Type: application/json" --data '{
+   "message":{
+      "encryptedMessage":"A4SqpsrYEf2a3XWdYQ5h3SukMZEQZWbd1VU=",
+      "salt":"63zV+FGiXDCewU4BqSQgkg==",
+      "nonce":"7KxHxQSmDlHdI2+tsZp5BpaZswKPayYx"
+   },
+   "password":"YdkNfIEro2aokq5l"
+}'
+```

--- a/formserver/build.gradle
+++ b/formserver/build.gradle
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     implementation project(':formfiller')
+    implementation project(':encryption')
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'

--- a/formserver/build.gradle
+++ b/formserver/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(':formfiller')
     implementation project(':encryption')
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation 'commons-codec:commons-codec:1.11'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 

--- a/formserver/src/main/java/com/diyasylum/formserver/controllers/EncryptionController.java
+++ b/formserver/src/main/java/com/diyasylum/formserver/controllers/EncryptionController.java
@@ -1,0 +1,41 @@
+package com.diyasylum.formserver.controllers;
+
+import com.diyasylum.encryption.PasswordGenerator;
+import com.diyasylum.encryption.SecretBox;
+import com.diyasylum.encryption.models.EncryptedMessage;
+import com.diyasylum.encryption.models.UnencryptedMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class EncryptionController {
+  private final HttpHeaders fillResponseHeaders;
+
+  @Autowired
+  public EncryptionController() {
+    this.fillResponseHeaders = getFillResponseHeaders();
+  }
+
+  private HttpHeaders getFillResponseHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setCacheControl("no-cache");
+    return headers;
+  }
+
+  @PostMapping("/encryption/v1")
+  @ResponseBody
+  public ResponseEntity<EncryptedMessage> encryptMessage(@RequestBody UnencryptedMessage message) {
+    String password = PasswordGenerator.getPassword();
+    SecretBox box = new SecretBox(password);
+    EncryptedMessage encryptedMessage = box.encrypt(message.getMessage()).get();
+    return new ResponseEntity<>(encryptedMessage, fillResponseHeaders, HttpStatus.OK);
+  }
+}

--- a/formserver/src/main/java/com/diyasylum/formserver/controllers/EncryptionController.java
+++ b/formserver/src/main/java/com/diyasylum/formserver/controllers/EncryptionController.java
@@ -1,8 +1,6 @@
 package com.diyasylum.formserver.controllers;
 
-import com.diyasylum.encryption.PasswordGenerator;
-import com.diyasylum.encryption.SecretBox;
-import com.diyasylum.encryption.models.EncryptedMessage;
+import com.diyasylum.encryption.EncryptionHandler;
 import com.diyasylum.encryption.models.EncryptionPackage;
 import com.diyasylum.encryption.models.UnencryptedMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,21 +32,15 @@ public class EncryptionController {
   @PostMapping("/encryption/v1")
   @ResponseBody
   public ResponseEntity<EncryptionPackage> encryptMessage(@RequestBody UnencryptedMessage message) {
-    String password = PasswordGenerator.getPassword();
-    SecretBox box = new SecretBox(password);
-    EncryptedMessage encryptedMessage = box.encrypt(message.getMessage()).get();
-    EncryptionPackage response = new EncryptionPackage(encryptedMessage, password);
-    return new ResponseEntity<>(response, fillResponseHeaders, HttpStatus.OK);
+    return new ResponseEntity<>(
+        EncryptionHandler.handleEncryption(message), fillResponseHeaders, HttpStatus.OK);
   }
 
   @PostMapping("/decryption/v1")
   @ResponseBody
   public ResponseEntity<UnencryptedMessage> decryptMessage(
       @RequestBody EncryptionPackage encryptionPackage) {
-    String password = encryptionPackage.getPassword();
-    EncryptedMessage encryptedMessage = encryptionPackage.getMessage();
-    SecretBox box = new SecretBox(password);
-    UnencryptedMessage message = new UnencryptedMessage(box.decrypt(encryptedMessage).get());
-    return new ResponseEntity<>(message, fillResponseHeaders, HttpStatus.OK);
+    return new ResponseEntity<>(
+        EncryptionHandler.handleDecryption(encryptionPackage), fillResponseHeaders, HttpStatus.OK);
   }
 }

--- a/formserver/src/test/java/com/diyasylum/formserver/controllers/EncryptionControllerUnitTest.java
+++ b/formserver/src/test/java/com/diyasylum/formserver/controllers/EncryptionControllerUnitTest.java
@@ -1,0 +1,62 @@
+package com.diyasylum.formserver.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.diyasylum.encryption.models.EncryptedMessage;
+import com.diyasylum.encryption.models.EncryptionPackage;
+import com.diyasylum.encryption.models.UnencryptedMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(EncryptionController.class)
+class EncryptionControllerUnitTest {
+  private MockMvc mockMvc;
+  private static Base64 base64 = new Base64();
+
+  @Autowired
+  EncryptionControllerUnitTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @Test
+  void testEncryptionPost() throws Exception {
+    UnencryptedMessage message = new UnencryptedMessage("message");
+    this.mockMvc
+        .perform(
+            post("/encryption/v1")
+                .content(new ObjectMapper().writeValueAsString(message))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"));
+  }
+
+  @Test
+  void testDecryptionPost() throws Exception {
+    EncryptedMessage encryptedMessage =
+        new EncryptedMessage(
+            base64.decodeBase64("itkNJqRclSElL/iaUugskBZCaCmXCf67coYuw3T5"),
+            base64.decodeBase64("C1wxtjxCPusWK1naAnnVyQ=="),
+            base64.decodeBase64("7yKw+IMNRouQFrIv5P/sY+Ag3D4XVwbq"));
+    String password = "4nChZTTPYlOvCma5";
+    EncryptionPackage encryptionPackage = new EncryptionPackage(encryptedMessage, password);
+    UnencryptedMessage message = new UnencryptedMessage("secret message");
+    this.mockMvc
+        .perform(
+            post("/decryption/v1")
+                .content(new ObjectMapper().writeValueAsString(encryptionPackage))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(content().json(new ObjectMapper().writeValueAsString(message)));
+  }
+}


### PR DESCRIPTION
This PR adds two endpoints for encryption and decryption of user state. Example requests are given in the README. User state is sent to the encryption endpoint, which randomly generates a password and encrypts the user's data using that password. When the user wants to recover their state, they send the same payload back to the decryption endpoint, which supplies them with their state. 

Most of the code here is either serialization or tests of serialization. The only additional logic is captured in EncryptionHandler. 

The new endpoints will not work with the Docker build (and the build itself may be broken due to some logging dependency conflict that I haven't sorted out yet). I figure this is a large enough PR without the Docker changes and we can handle that next. 

