### PR TITLE
create a docker build independent from gradle

### DIFF
--- a/formserver/Dockerfile
+++ b/formserver/Dockerfile
@@ -1,14 +1,19 @@
-FROM openjdk:11
-VOLUME /tmp
-ARG DEPENDENCY=target/dependency
-COPY ${DEPENDENCY}/BOOT-INF/lib /app/lib
-COPY ${DEPENDENCY}/META-INF /app/META-INF
-COPY ${DEPENDENCY}/BOOT-INF/classes /app
+# Build this docker container from the root of the monorepo (see readme)
+FROM openjdk:11 as builder
+RUN \
+    apt-get update -yq \
+    && apt-get install curl gnupg -yq \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+    && apt-get install nodejs -yq
+COPY . /usr/src/formfiller
+WORKDIR /usr/src/formfiller
+RUN ./gradlew :formserver:assemble
 
+
+FROM openjdk:11
 RUN \
     apt-get update && \
     apt-get -y install curl build-essential unzip
-
 RUN \
     mkdir -p /tmpbuild/libsodium && \
     cd /tmpbuild/libsodium && \
@@ -20,5 +25,6 @@ RUN \
     make install && \
     mv src/libsodium /usr/local/ && \
     rm -Rf /tmpbuild/
+COPY --from=builder /usr/src/formfiller/formserver/build/libs/formServer.jar .
 
-ENTRYPOINT ["java","-cp","app:app/lib/*","com.diyasylum.formserver.FormserverApplication"]
+ENTRYPOINT ["java", "-jar", "formServer.jar"]

--- a/formserver/README.md
+++ b/formserver/README.md
@@ -34,8 +34,10 @@ This will fill in one field of the pdf with the text batman and pipe the result 
 
 This module includes a dockerfile for its deployment. You can build and run the server with the following commands
 
+*Make sure you run this from the root of the monorepo as the dockerfile builds the jar*
+
 ```bash
-./gradlew :formserver:build :formserver:docker
+docker build -t diyasylum/formserver -f formserver/Dockerfile .
 docker run -p 8080:8080 -t diyasylum/formserver
 ```
 

--- a/formserver/build.gradle
+++ b/formserver/build.gradle
@@ -7,12 +7,10 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath('gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.21.0')
     }
 }
 
 plugins {
-    id "com.palantir.docker" version "0.21.0"
     id 'org.springframework.boot' version "2.1.2.RELEASE"
     id 'io.spring.dependency-management' version "1.0.6.RELEASE"
 }
@@ -33,19 +31,12 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 }
 
-task unpack(type: Copy) {
-    dependsOn bootJar
-    from(zipTree(tasks.bootJar.outputs.files.singleFile))
-    into("build/dependency")
-}
-docker {
-    name "diyasylum/${bootJar.baseName}"
-    copySpec.from(tasks.unpack.outputs).into("dependency")
-    buildArgs(['DEPENDENCY': "dependency"])
-}
-
 configurations {
     all {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
+}
+
+bootJar {
+    archiveName = 'formServer.jar'
 }


### PR DESCRIPTION
Breaks the server docker free from the gradle build.

The multistage docker should mean the final container is still just the jar and the dependencies to run the jar.